### PR TITLE
Fix Telegram bot starter dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots-spring-boot-starter</artifactId>
-            <version>6.8.1</version>
+            <version>6.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Summary
- fix telegrambots-spring-boot-starter version to 6.8.0 so Maven can resolve artifacts

## Testing
- `docker-compose up -d` *(fails: command not found)*
- `mvn -q test` *(fails: Non-resolvable parent POM: could not transfer Spring Boot starter parent)*

------
https://chatgpt.com/codex/tasks/task_e_689725d8d9748330acc2d5df7f00c7bc